### PR TITLE
Proxy: default to accepting any method

### DIFF
--- a/pkg/proxy/definition.go
+++ b/pkg/proxy/definition.go
@@ -114,7 +114,7 @@ type ForwardingTimeouts struct {
 // NewDefinition creates a new Proxy Definition with default values
 func NewDefinition() *Definition {
 	return &Definition{
-		Methods: []string{"GET"},
+		Methods: []string{methodAll},
 		Hosts:   make([]string, 0),
 		Upstreams: &Upstreams{
 			Targets: make([]*Target, 0),

--- a/pkg/proxy/definition_test.go
+++ b/pkg/proxy/definition_test.go
@@ -61,7 +61,7 @@ func TestDefinition(t *testing.T) {
 func testNewDefinitions(t *testing.T) {
 	definition := NewDefinition()
 
-	assert.Equal(t, []string{"GET"}, definition.Methods)
+	assert.Equal(t, []string{"ALL"}, definition.Methods)
 	assert.NotNil(t, definition)
 }
 


### PR DESCRIPTION
Currently, only `GET` requests are allowed when the `methods` field is not specified. This does not match documented behaviour:

https://github.com/motiv-labs/janus/blob/aa38d1390fac2df7a07be16377b31093fa66eb90/docs/proxy/request_http_method.md?plain=1#L3-L6

This PR makes the proxy default to accepting any method.